### PR TITLE
Implement levelDB

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,29 @@
+package config
+
+import "path"
+
+const (
+	DEFAULT_REGENT_DATADIR  = "/Users/prestonevans/sovereign/regent"
+	DEFAULT_ERIGON_DATADIR  = "/Users/prestonevans/sovereign/"
+	JWT_SECRET_FILENAME     = "jwt.hex"
+	DEFAULT_ENGINE_RPC_PORT = "8551"
+)
+
+var ErigonDatadir = DEFAULT_ERIGON_DATADIR
+var EngineRpcPort string = DEFAULT_ENGINE_RPC_PORT
+
+type Config struct {
+	ErigonDatadir string
+	EngineRpcPort string
+	JwtSecretPath string
+	RegentDatadir string
+}
+
+func New() *Config {
+	return &Config{
+		ErigonDatadir: DEFAULT_ERIGON_DATADIR,
+		JwtSecretPath: path.Join(DEFAULT_ERIGON_DATADIR, JWT_SECRET_FILENAME),
+		EngineRpcPort: DEFAULT_ENGINE_RPC_PORT,
+		RegentDatadir: DEFAULT_REGENT_DATADIR,
+	}
+}

--- a/db/db.go
+++ b/db/db.go
@@ -1,0 +1,63 @@
+package db
+
+import (
+	"github.com/ledgerwatch/erigon-lib/kv"
+)
+
+const DEFAULT_REGENT_DATADIR = "/Users/prestonevans/sovereign/regent"
+
+var regentDatadir = DEFAULT_REGENT_DATADIR
+
+type SimpleDb interface {
+	Get(table string, key []byte) (val []byte, err error)
+	kv.Putter
+	kv.Deleter
+	kv.Closer
+}
+type Iterator interface {
+	// First moves the iterator to the first key/value pair. If the iterator
+	// only contains one key/value pair then First and Last move
+	// to the same key/value pair.
+	// Returns false if and only if the iterator is empty
+	First() bool
+
+	// Last moves the iterator to the last key/value pair. If the iterator
+	// only contains one key/value pair then First and Last move
+	// to the same key/value pair.
+	// Returns false if and only if the iterator is empty
+	Last() bool
+
+	// Seek moves the iterator to the first key/value pair whose key is greater
+	// than or equal to the given key.
+	// Returns true only if such a key exists
+	//
+	// It is safe to modify the contents of the argument after Seek returns.
+	Seek(key []byte) bool
+
+	// Next moves the iterator to the next key/value pair.
+	// Returns false if the iterator is exhausted.
+	Next() bool
+
+	// Prev moves the iterator to the previous key/value pair.
+	// Returns false if the iterator is exhausted.
+	Prev() bool
+
+	// Key returns the key of the current key/value pair, or nil if done.
+	// The caller should not modify the contents of the returned slice, and
+	// its contents may change on the next call to the iterator
+	Key() []byte
+
+	// Value returns the value of the current key/value pair, or nil if done.
+	// The caller should not modify the contents of the returned slice, and
+	// its contents may change on the next call to the iterator
+	Value() []byte
+
+	// Releases any resources held by this iterator. Callers must invoke this method
+	// before dropping the iterator
+	Release()
+}
+
+type RangeDb interface {
+	SimpleDb
+	GetRange(table string) Iterator
+}

--- a/db/leveldb.go
+++ b/db/leveldb.go
@@ -1,0 +1,100 @@
+package db
+
+import (
+	"regent/utils"
+
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+	"github.com/syndtr/goleveldb/leveldb/storage"
+	"github.com/syndtr/goleveldb/leveldb/util"
+)
+
+var defaultReadOptions = &opt.ReadOptions{
+	Strict: opt.DefaultStrict,
+}
+var defaultWriteOptions = &opt.WriteOptions{}
+
+// A simple wrapper over the levelDB package.
+// The underlying DB can be read and written to concurrently.
+// Implements the SimpleDb and RangeDb interfaces.
+type LevelDB struct {
+	inner *leveldb.DB
+}
+
+// Opens a new DB at the provided path.
+//
+// The returned DB instance is safe for concurrent use.
+// The DB must be closed after use, by calling Close method.
+func NewLevelDB(path string) (*LevelDB, error) {
+	db, err := leveldb.OpenFile(path, nil)
+	if err != nil {
+		return nil, err
+	}
+	return levelDbFromInner(db, nil)
+}
+
+// Creates an in-memory levleDB instance.
+// This database will not persist across shutdowns (obviously!)
+func InMemoryDb() (*LevelDB, error) {
+	return levelDbFromInner(leveldb.Open(storage.NewMemStorage(), nil))
+}
+
+func levelDbFromInner(db *leveldb.DB, err error) (*LevelDB, error) {
+	if err != nil {
+		return nil, err
+	}
+	output := &LevelDB{inner: db}
+	err = PutRollupBlockHashWithNumber(output, utils.GENESIS_HASH, 0)
+	if err != nil {
+		db.Close()
+		return nil, err
+	}
+	return output, nil
+}
+
+// Close closes the DB. This will also release any outstanding snapshots, abort any in-flight compaction, and discard any open transactions.
+// It is not safe to close a DB until all outstanding iterators are released.
+// It is valid to call Close multiple times. Other methods should not be called after the DB has been closed.
+func (db *LevelDB) Close() {
+	db.inner.Close()
+}
+
+// Get gets the value for the given key. It returns ErrNotFound if the DB does not contains the key.
+// The returned slice is a copy, so it is safe to modify the contents of the returned slice.
+// It is safe to modify the contents of the argument after Get returns.
+func (db *LevelDB) Get(table string, key []byte) ([]byte, error) {
+	return db.inner.Get(keyFor(table, key), defaultReadOptions)
+}
+
+// Put sets the value for the given key. It overwrites any previous value for that key;
+// When Put is used concurrently and the batch is small enough, leveldb will try to merge the batches.
+// Set the NoWriteMerge option to true to disable this behavior.
+// It is safe to modify the contents of the arguments after Put returns but not before.
+func (db *LevelDB) Put(table string, k []byte, v []byte) error {
+	return db.inner.Put(keyFor(table, k), v, defaultWriteOptions)
+}
+
+// Delete deletes the value for the given key. Delete will not returns error if key doesn't exist.
+// Write merge also applies to Delete. See the doc comment on Put for more information.
+// It is safe to modify the contents of the arguments after Delete returns but not before.
+func (db *LevelDB) Delete(table string, k []byte) error {
+	return db.inner.Delete(keyFor(table, k), defaultWriteOptions)
+}
+
+// Get all keys from start up to (but not including) end
+// Remember that the contents of the returned slice should not be modified, and
+// are only valid until the next call to Next.
+func (db *LevelDB) GetRange(table string) Iterator {
+	return db.inner.NewIterator(util.BytesPrefix([]byte(table)), nil)
+}
+
+// Combine a tablename and key into a single string. Use the combined string
+// as the new key to work around the lack of tables in leveldb. This still allows
+// efficient iterations over 'tables', since level DB stores keys in sorted order
+func keyFor(table string, key []byte) []byte {
+	output := make([]byte, 0, len(table)+len(key))
+	output = append(output, []byte(table)...)
+	return append(output, key...)
+}
+
+var _ RangeDb = &LevelDB{}

--- a/db/schema.go
+++ b/db/schema.go
@@ -1,0 +1,189 @@
+package db
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/ledgerwatch/erigon/common"
+)
+
+const (
+	RollupBlockNumberToHash = "RollupBlockNumberToHash"
+	RollupBlockHashToNumber = "RollupBlockHashToNumber"
+)
+
+var (
+	ERR_INVALID_U64        = errors.New("could not unmarshal slice as a uint64. The length must be exactly 8 bytes. This likely indicates db corruption")
+	ERR_INVALID_BLOCK_HASH = errors.New("could not unmarshal slice as a hash. The length must be exactly 32 bytes. This likely indicates db corruption")
+	ERR_NOT_FOUND          = errors.New("the requested item could note be found in the database. requested: ")
+	ERR_EXHAUSTED          = errors.New("the iterator is exhausted")
+	ERR_PAST_HEAD          = errors.New("the requested block is beyond the tip of the known chain")
+	ERR_MISSING            = errors.New("the requested block was not found, but a more recent block was.")
+)
+
+// The error returned when an item could not be found in the database
+type NotFoundError struct {
+	inner error
+	msg   string
+}
+
+func (e *NotFoundError) Error() string {
+	return fmt.Sprintf("%s. %s. ", e.msg, e.inner)
+}
+
+func (e *NotFoundError) Unwrap() error {
+	return e.inner
+}
+
+func (e *NotFoundError) Is(err error) bool {
+	return strings.HasPrefix(err.Error(), ERR_NOT_FOUND.Error()) || errors.Is(err, ERR_NOT_FOUND)
+}
+
+// An double-ended iterator over all block hashes, ordered by height.
+// The iterator may panic if the databse is empty, so callers should ensure
+// that the underlying database contains at least the Genesis block at all times.
+type BlockHashIterator struct {
+	inner      Iterator
+	atHead     bool
+	headHeight uint64
+}
+
+// Get a DbIterator over the rollup block hashes, ordered by block number
+func GetBlockHashIterator(db RangeDb) *BlockHashIterator {
+	iter := &BlockHashIterator{
+		inner: db.GetRange(RollupBlockNumberToHash),
+	}
+	iter.inner.Last()
+	iter.headHeight = unwrap(extractBlockNumFromKey(iter.inner.Key()))
+	iter.inner.First()
+	return iter
+}
+
+// Read the current hash from the iterator, and advance it one spot
+// Returns an error if and only if the iterator is exhausted
+func (blocks *BlockHashIterator) Next() (common.Hash, error) {
+	if blocks.inner.Key() != nil {
+		res, err := UnmarshallHash(blocks.inner.Value())
+		blocks.atHead = !blocks.inner.Next()
+		return unwrap(res, err), nil
+	}
+	return common.Hash{}, ERR_EXHAUSTED
+}
+
+// Return the current hash from the iterator, and move it back one spot
+// Returns an error if and only if the iterator is exhausted
+func (blocks *BlockHashIterator) Prev() (common.Hash, error) {
+	blocks.atHead = false
+	if !blocks.inner.Prev() {
+		blocks.inner.First()
+		return common.Hash{}, ERR_EXHAUSTED
+	}
+	res, err := UnmarshallHash(blocks.inner.Value())
+	return unwrap(res, err), nil
+}
+
+// Return the block number of the hash that the iterator will yield next, without moving the iterator
+// If the iterator is at the end of its range, this will return a number one greater than the head height
+func (blocks *BlockHashIterator) Position() uint64 {
+	if blocks.atHead {
+		return blocks.headHeight + 1
+	}
+	return unwrap(extractBlockNumFromKey(blocks.inner.Key()))
+}
+
+// Return the current hash from the iterator without moving the iterator
+// Returns an error if and only if the iterator is exhausted
+func (blocks *BlockHashIterator) Peek() (common.Hash, error) {
+	if !blocks.atHead {
+		return unwrap(UnmarshallHash(blocks.inner.Value())), nil
+	}
+	return common.Hash{}, ERR_EXHAUSTED
+}
+
+// Set the iterator to the latest block, and return its hash
+func (blocks *BlockHashIterator) JumpToHead() common.Hash {
+	blocks.inner.Last()
+	blocks.atHead = true
+	return unwrap(UnmarshallHash(blocks.inner.Value()))
+}
+
+// Return the block height of the largest block contained in this iterator
+func (blocks *BlockHashIterator) MaxHeight() uint64 {
+	return blocks.headHeight
+}
+
+// Set the iterator to the genesis block, and return its hash
+func (blocks *BlockHashIterator) JumpToGenesis() common.Hash {
+	blocks.inner.First()
+	blocks.atHead = false
+	return unwrap(UnmarshallHash(blocks.inner.Value()))
+}
+
+// Set the iterator to the block at the provided height, and return its hash
+// Returns an error only if the provided block number does not exist in the database
+func (blocks *BlockHashIterator) Seek(number uint64) (common.Hash, error) {
+	if !blocks.inner.Seek(keyFor(RollupBlockNumberToHash, MarshalUint(number))) {
+		blocks.atHead = true
+		return common.Hash{}, &NotFoundError{
+			inner: ERR_PAST_HEAD,
+			msg:   fmt.Sprintf("block %v was not found in the database. The latest block is only %v", number, blocks.MaxHeight()),
+		}
+	}
+	newPosition := unwrap(extractBlockNumFromKey(blocks.inner.Key()))
+	if newPosition != number {
+		return common.Hash{}, &NotFoundError{
+			inner: ERR_MISSING,
+			msg:   fmt.Sprintf("block %v was missing from the database. Found %v in its place.", number, newPosition),
+		}
+	}
+	return unwrap(UnmarshallHash(blocks.inner.Value())), nil
+}
+
+// Cleans up any resources held by this iterator - typically a database snapshot
+// Callers must invoke this method before dropping the iterator
+func (blocks *BlockHashIterator) Release() {
+	blocks.inner.Release()
+}
+
+// Store a new rollup block hash in the database. Stores the mapping from hash->number and from number->hash
+func PutRollupBlockHashWithNumber(db SimpleDb, blockhash common.Hash, blocknumber uint64) error {
+	err := db.Put(RollupBlockHashToNumber, blockhash[:], MarshalUint(blocknumber))
+	if err != nil {
+		return err
+	}
+	return db.Put(RollupBlockNumberToHash, MarshalUint(blocknumber), blockhash[:])
+}
+
+// Looks up the block number corresponding to the provided hash in the database
+func GetRollupBlockNumber(db SimpleDb, blockhash common.Hash) (uint64, error) {
+	raw, err := db.Get(RollupBlockHashToNumber, blockhash[:])
+	if err != nil {
+		return 0, &NotFoundError{
+			inner: err,
+			msg:   fmt.Sprintf("%s blockhash %v in table %s", ERR_NOT_FOUND, blockhash, RollupBlockHashToNumber),
+		}
+	}
+	return UnmarshallUint(raw)
+}
+
+// Looks up the block hash for the provided block number in the database
+func GetRollupBlockHash(db SimpleDb, blocknum uint64) (common.Hash, error) {
+	raw, err := db.Get(RollupBlockNumberToHash, MarshalUint(blocknum))
+	if err != nil {
+		return common.Hash{}, &NotFoundError{
+			inner: err,
+			msg:   fmt.Sprintf("%s blocknumber %v in table %s", ERR_NOT_FOUND, blocknum, RollupBlockNumberToHash),
+		}
+	}
+	return UnmarshallHash(raw)
+}
+
+// Remove the tablename prefix from a key in the `RollupBlockNumberToHash` table,
+// then unmarshall the remaining bytes as a blocknumber
+func extractBlockNumFromKey(raw []byte) (uint64, error) {
+	if len(raw) < len(RollupBlockNumberToHash) {
+		return 0, fmt.Errorf("%s did not contain a valid block number with prefix %s. %w", raw, RollupBlockNumberToHash, ERR_INVALID_U64)
+	}
+	return UnmarshallUint(raw[len(RollupBlockNumberToHash):])
+}

--- a/db/schema_test.go
+++ b/db/schema_test.go
@@ -1,0 +1,265 @@
+package db
+
+import (
+	"errors"
+	"regent/utils"
+	"testing"
+
+	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/crypto"
+)
+
+var testHashes []common.Hash
+
+func init() {
+	for i := uint64(0); i < 10; i++ {
+		testHashes = append(testHashes, crypto.Keccak256Hash(MarshalUint(i)))
+	}
+}
+
+func assertErrs[T any](f func() (T, error), expected error, t *testing.T) {
+	_, err := f()
+	if !errors.Is(err, expected) {
+		t.Fatalf("function should have failed with %v but returned the following err: %v", expected, err)
+	}
+}
+
+func testRead(db SimpleDb, expectedHash common.Hash, expectedNumber uint64, t *testing.T) {
+	actualHash, err := GetRollupBlockHash(db, expectedNumber)
+	if err != nil {
+		t.Fatal("unable to retrieve block hash from db", err)
+	}
+	if actualHash != expectedHash {
+		t.Fatalf("incorrect genesis hash. expected: %v. got: %v", expectedHash, actualHash)
+	}
+
+	actualNumber, err := GetRollupBlockNumber(db, expectedHash)
+	if err != nil {
+		t.Fatal("unable to retrieve block from db", err)
+	}
+	if actualNumber != expectedNumber {
+		t.Fatalf("incorrect block number. expected: %v. got: %v", expectedNumber, actualNumber)
+	}
+}
+
+func testDelete(db SimpleDb, hash common.Hash, number uint64, t *testing.T) {
+	err := db.Delete(RollupBlockNumberToHash, MarshalUint(number))
+	if err != nil {
+		t.Fatal("unable to delete block number from db:", number)
+	}
+	db.Delete(RollupBlockHashToNumber, hash[:])
+	if err != nil {
+		t.Fatal("unable to delete block hash from db:", hash)
+	}
+
+	_, err = GetRollupBlockHash(db, number)
+	if err == nil || !errors.Is(err, ERR_NOT_FOUND) {
+		t.Fatalf("deletion failed. lookup receieved: %v. expected: %v.", err, ERR_NOT_FOUND)
+	}
+
+	_, err = GetRollupBlockNumber(db, hash)
+	if err == nil || !errors.Is(err, ERR_NOT_FOUND) {
+		t.Fatalf("deletion failed. lookup receieved: %v. expected: %v.", err, ERR_NOT_FOUND)
+	}
+}
+
+func testCrud(db SimpleDb, hash common.Hash, number uint64, t *testing.T) {
+	// Insert the items and read them back
+	err := PutRollupBlockHashWithNumber(db, hash, number)
+	if err != nil {
+		t.Fatal("unable to insert block hash into db:", err)
+	}
+	testRead(db, hash, number, t)
+
+	// Change the hash and read the items back again
+	updatedHash := crypto.Keccak256Hash(hash[:])
+	err = PutRollupBlockHashWithNumber(db, updatedHash, number)
+	if err != nil {
+		t.Fatal("unable to update block hash in db:", err)
+	}
+	testRead(db, updatedHash, number, t)
+	// Delete the items, and verify that they disappear
+	testDelete(db, hash, number, t)
+}
+
+func TestCrudOperations(t *testing.T) {
+	db, err := InMemoryDb()
+	if err != nil {
+		t.Fatal("unable to create test db in tempdir", err)
+	}
+	defer db.Close()
+
+	// Run all CRUD operations on the genesis hash (which may be special cased in impls)
+	testCrud(db, utils.GENESIS_HASH, 0, t)
+	// Run all CRUD operations on a different hash
+	testCrud(db, crypto.Keccak256Hash(MarshalUint(100)), 100, t)
+}
+
+// Test that a fresh DB contains the genesis block and behaves as expected
+func TestIteratorOperations_emptyDb(t *testing.T) {
+	db, err := InMemoryDb()
+	if err != nil {
+		t.Fatal("unable to create test db in tempdir", err)
+	}
+	defer db.Close()
+	blocksIter := GetBlockHashIterator(db)
+	defer blocksIter.Release()
+
+	// The genesis block should be equal to the head block
+	if blocksIter.JumpToGenesis() != blocksIter.JumpToHead() ||
+		blocksIter.MaxHeight() != 0 {
+		t.Fatal("empty database should return genesis as its head block")
+	}
+	// The first call to next should return the genesis block and move us to the `done` marker
+	res, err := blocksIter.Next()
+	if res != utils.GENESIS_HASH || err != nil {
+		t.Fatalf("Cursor should have been at the genesis block. failed with the following error: %s", err)
+	}
+	// Any susbsequent calls to next should not move the cursor or return a value
+	assertErrs(blocksIter.Next, ERR_EXHAUSTED, t)
+	assertErrs(blocksIter.Next, ERR_EXHAUSTED, t)
+	if int(blocksIter.Position()) != 1 {
+		t.Fatalf("The cursor should not keep moving past the head of the chain. expected position: %v got: %v", 1, blocksIter.Position())
+	}
+
+	// The first call to Prev should get us back to the genesis block
+	res, err = blocksIter.Prev()
+	if res != utils.GENESIS_HASH || err != nil {
+		t.Fatalf("Cursor should have been at the genesis block. failed with the following error: %s", err)
+	}
+
+	// Any additional calls to Prev should should not move the cursor beyond the beginning of the array
+	assertErrs(blocksIter.Prev, ERR_EXHAUSTED, t)
+	assertErrs(blocksIter.Prev, ERR_EXHAUSTED, t)
+	if int(blocksIter.Position()) != 0 {
+		t.Fatalf("The cursor should not keep moving before the genesis block. expected position: %v got: %v", 0, blocksIter.Position())
+	}
+
+	res, err = blocksIter.Peek()
+	if res != utils.GENESIS_HASH || err != nil {
+		t.Fatalf("Cursor should have been at the genesis block. failed with the following error: %s", err)
+	}
+
+	// After calling peeek the cursor should be in the same place
+	blocknum := blocksIter.Position()
+	if blocknum != 0 {
+		t.Fatalf("Cursor should have been at height 0. failed with the following error: %s", err)
+	}
+
+	// Ensure that Seek is able to get us to the genesis block
+	res, err = blocksIter.Seek(0)
+	if res != utils.GENESIS_HASH || err != nil {
+		t.Fatalf("Seek 0 should always succeed, but failed with the following error: %s", err)
+	}
+
+	// Seeking the next block should fail
+	_, err = blocksIter.Seek(1)
+	if err == nil || !errors.Is(err, ERR_NOT_FOUND) || !errors.Is(err, ERR_PAST_HEAD) {
+		t.Fatalf("Seek 1 failed with the wrong error. expected: %v. got: %s", ERR_PAST_HEAD, err)
+	}
+}
+
+func TestIteratorOperations_completeDb(t *testing.T) {
+	db, err := InMemoryDb()
+	if err != nil {
+		t.Fatal("unable to create test db in tempdir", err)
+	}
+	defer db.Close()
+
+	// Overwrite the genesis block and add some additional test hashes to the db
+	for i, hash := range testHashes {
+		PutRollupBlockHashWithNumber(db, hash, uint64(i))
+	}
+
+	blocksIter := GetBlockHashIterator(db)
+	defer blocksIter.Release()
+
+	// Check each method while iterating forwards
+	for idx, expected := range testHashes {
+		i := uint64(idx)
+		if blocksIter.Position() != i {
+			t.Fatalf("Incorrect next height. expected %v. got %v", i, blocksIter.Position())
+		}
+		got := unwrap(blocksIter.Peek())
+		if got != expected {
+			t.Fatalf("Peek returned the wrong value. expected: %v. got: %v", expected, got)
+		}
+		got = unwrap(blocksIter.Next())
+		if expected != got {
+			t.Fatalf("Peek and next must return the same value. expected: %v. got: %v", expected, got)
+		}
+	}
+	assertErrs(blocksIter.Next, ERR_EXHAUSTED, t)
+	assertErrs(blocksIter.Peek, ERR_EXHAUSTED, t)
+
+	// Check each method while iterating backwards
+	for i := uint64(len(testHashes)); i != 0; i-- {
+		expected := testHashes[i-1]
+		if blocksIter.Position() != i {
+			t.Fatalf("Incorrect next height. expected: %v. got: %v", i, blocksIter.Position())
+		}
+		got := unwrap(blocksIter.Prev())
+		if got != expected {
+			t.Fatalf("i: %v. Prev returned the wrong value. expected: %v. got: %v", i, expected, got)
+		}
+	}
+	assertErrs(blocksIter.Prev, ERR_EXHAUSTED, t)
+
+	got := unwrap(blocksIter.Peek())
+	if got != testHashes[0] {
+		t.Fatalf("Iterator should be back to genesis, but was at position %v with hash %v", blocksIter.Position(), got)
+	}
+}
+
+func TestBlocksIterator_withMissingValues(t *testing.T) {
+	db, err := InMemoryDb()
+	if err != nil {
+		t.Fatal("unable to create test db in tempdir", err)
+	}
+	defer db.Close()
+
+	err = PutRollupBlockHashWithNumber(db, testHashes[5], 5)
+	if err != nil {
+		t.Fatal("insertion into an open db should succeed but failed with err:", err)
+	}
+
+	blocksIter := GetBlockHashIterator(db)
+	defer blocksIter.Release()
+
+	_, err = blocksIter.Seek(3)
+	if err == nil || !errors.Is(err, ERR_NOT_FOUND) || !errors.Is(err, ERR_MISSING) {
+		t.Fatalf("seeking a missing block must return an error. expected: %v. got: %v.", ERR_MISSING, err)
+	}
+
+	if blocksIter.Position() != 5 {
+		t.Fatalf("wrong position! expected: %v. got: %v.", 5, blocksIter.Position())
+	}
+	blocksIter.Prev()
+	if blocksIter.Position() != 0 {
+		t.Fatalf("wrong position! expected: %v. got: %v.", 0, blocksIter.Position())
+	}
+	blocksIter.Next()
+	if blocksIter.Position() != 5 {
+		t.Fatalf("wrong position! expected: %v. got: %v.", 5, blocksIter.Position())
+	}
+}
+
+func TestInsertIntoClosedDb(t *testing.T) {
+	db, err := InMemoryDb()
+	if err != nil {
+		t.Fatal("unable to create test db in tempdir", err)
+	}
+	db.Close()
+
+	err = PutRollupBlockHashWithNumber(db, utils.GENESIS_HASH, 0)
+	if err == nil {
+		t.Fatal("inserting into a closed db must throw")
+	}
+}
+
+func TestExtractBlockNumFromKey_notPrefixedWithKey(t *testing.T) {
+	_, err := extractBlockNumFromKey(make([]byte, 8))
+	if err == nil || !errors.Is(err, ERR_INVALID_U64) {
+		t.Fatalf("must not remove a non-existent prefix. expected err: %v. got %v", ERR_INVALID_U64, err)
+	}
+}

--- a/db/utils.go
+++ b/db/utils.go
@@ -1,0 +1,52 @@
+package db
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/log/v3"
+)
+
+const (
+	serializedUint64Len = 8
+	serializedHashLen   = 32
+)
+
+// Marshall a uint64 into a slice of 8 bytes in BigEndian order
+func MarshalUint(num uint64) []byte {
+	out := make([]byte, 0, serializedUint64Len)
+	return binary.BigEndian.AppendUint64(out, num)
+}
+
+// Unmarshall a slice of 8 bytes into a uint64. Return an error
+// if the length of the slice is not equal to 8.
+// Uses BigEndian order
+func UnmarshallUint(raw []byte) (uint64, error) {
+	if len(raw) != serializedUint64Len {
+		return 0, fmt.Errorf("slice had invalid length %v: %w", len(raw), ERR_INVALID_U64)
+	}
+	return binary.BigEndian.Uint64(raw), nil
+}
+
+// Unmarshall a slice of 32 bytes into a Hash. Return an error
+// if the length of the slice is not equal to 32
+func UnmarshallHash(raw []byte) (common.Hash, error) {
+	output := common.Hash{}
+	if len(raw) != serializedHashLen {
+		return output, fmt.Errorf("slice had invalid length %v: %w", len(raw), ERR_INVALID_BLOCK_HASH)
+	}
+	copy(output[:], raw)
+	return output, nil
+}
+
+// Convert a tuple of (result, error) into only a result by panicking if the error is non-nil
+// This function should only be used in situations where the error is both unexpected and unrecoverable
+// such as when database corruption occurs.
+func unwrap[T any](res T, err error) T {
+	if err != nil {
+		log.Crit("An unrecoverable error occurred. Panicking", "err", err)
+		panic(err)
+	}
+	return res
+}

--- a/db/utils_test.go
+++ b/db/utils_test.go
@@ -1,0 +1,22 @@
+package db
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestUnmarshalUint_wrongLen(t *testing.T) {
+	raw := make([]byte, 50)
+	_, err := UnmarshallUint(raw)
+	if err == nil || !errors.Is(err, ERR_INVALID_U64) {
+		t.Fatalf("unmarshalling a uint64 must fail if the slice length is not 8. expected: %v. got: %v.", ERR_INVALID_U64, err)
+	}
+}
+
+func TestUnmarshalHash_wrongLen(t *testing.T) {
+	raw := make([]byte, 50)
+	_, err := UnmarshallHash(raw)
+	if err == nil || !errors.Is(err, ERR_INVALID_BLOCK_HASH) {
+		t.Fatalf("unmarshalling a uint64 must fail if the slice length is not 8. expected: %v. got: %v.", ERR_INVALID_BLOCK_HASH, err)
+	}
+}

--- a/docs/adr/leveldb.md
+++ b/docs/adr/leveldb.md
@@ -1,0 +1,34 @@
+# Using LevelDB as Regent's Database
+
+## Authors
+
+Preston Evans - preston@sovlabs.io
+
+## Status
+
+Proposed
+
+## Context
+
+Like all blockchain clients, Regent will require a database to persist information across shutdowns. We need to decide on an underlying DB implementation. The data to be stored includes:
+
+- A mapping from DA block number to DA block hash
+- A mapping from DA block hash to DA block number
+- A mapping from DA block hash to DA block data
+- A mapping from DA block hash to the Intermediate merkle hashes needed to validate the rollup data using the namespaced merkle tree
+- A mapping from rollup block number to rollup block hash
+- A mapping from rollup block hash to rollup block data
+- A mapping from rollup block number to rollup block hash
+- A mapping from rollup block number to DA block number
+- The most recent observed validity proof
+  etc.
+
+## Decision
+
+We propose to use LevelDB as the database implementation for Regent. As a log-structured database, LevelDB provides excellent write throughput and high reliability.
+
+The primary drawbacks of LevelDB are its lack of MVCC and its lack of support for transactions. Since our rollup cannot "re-org", MVCC is not needed. In addition, we don't anticipate the need for any queries more complex than a simple range over block data, so the lack of transactions and complex query support is not an issue.
+
+## Consequences
+
+LevelDB will allow us to persist data with high performance and minimal maintenance burden.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,9 @@ go 1.19
 require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/ledgerwatch/erigon v1.9.7-0.20220815114851-35c4faa1b41e
+	github.com/ledgerwatch/erigon-lib v0.0.0-20220814135647-e160c1ad9ca1
 	github.com/ledgerwatch/log/v3 v3.4.1
+	github.com/syndtr/goleveldb v1.0.0
 )
 
 require (
@@ -71,7 +73,6 @@ require (
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kevinburke/go-bindata v3.21.0+incompatible // indirect
-	github.com/ledgerwatch/erigon-lib v0.0.0-20220814135647-e160c1ad9ca1 // indirect
 	github.com/ledgerwatch/secp256k1 v1.0.0 // indirect
 	github.com/lispad/go-generics-tools v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -581,6 +581,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
+github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tendermint/go-amino v0.14.1 h1:o2WudxNfdLNBwMyl2dqOJxiro5rfrEaU0Ugs6offJMk=
 github.com/tendermint/go-amino v0.14.1/go.mod h1:i/UKE5Uocn+argJJBb12qTZsCDBcAYMbR92AaJVmKso=
 github.com/tendermint/tendermint v0.31.11 h1:TIs//4WfEAG4TOZc2eUfJPI3T8KrywXQCCPnGAaM1Wo=

--- a/regent/main.go
+++ b/regent/main.go
@@ -6,15 +6,8 @@ import (
 	"regent/utils"
 	"time"
 
-	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/log/v3"
 )
-
-const DEFAULT_ERIGON_DATADIR = "/Users/prestonevans/sovereign"
-const JWT_SECRET_FILENAME = "jwt.hex"
-
-var ErigonDatadir = DEFAULT_ERIGON_DATADIR
-var EngineRpcPort string = "8551"
 
 func main() {
 	log.Root().SetHandler(log.LvlFilterHandler(log.LvlInfo, log.StderrHandler))
@@ -23,11 +16,12 @@ func main() {
 	if err != nil {
 		log.Crit("Fatal error attempting to start app", "err", err)
 	}
+	defer regent.DB.Close()
 
 	// Finalize the genesis block and start the building process
-	err = regent.ExtendChainAndStartBuilder(common.HexToHash(utils.GENESIS_HASH_STRING), utils.DEV_ADDRESS)
+	err = regent.ExtendChainAndStartBuilder(regent.CurrentHead, utils.DEV_ADDRESS)
 	if err != nil {
-		log.Crit("Could not finalize genesis block", "err", err)
+		log.Crit("Could not start building on current head", "err", err)
 		os.Exit(1)
 	}
 	// Wait for one second to ensure that the next payload builds with a future timestamp

--- a/regent/regent_test.go
+++ b/regent/regent_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 
+	"regent/db"
 	"regent/rpc"
 	"regent/utils"
 	"regent/utils/test"
@@ -19,9 +20,12 @@ var TestRegent Regent
 func init() {
 	TestRpcClient.Endpoint = test.TestServer.URL
 	rpc.DefaultRetryStrategy = func() rpc.RetryStrategy { return &test.NoRetryStrategy{} }
+	leveldb, _ := db.InMemoryDb()
 	TestRegent = Regent{
 		EngineRpc: TestRpcClient,
+		DB:        leveldb,
 	}
+	db.PutRollupBlockHashWithNumber(leveldb, utils.GENESIS_HASH, 0)
 }
 
 func TestExtendChainAndStartBuilder_successResponse(t *testing.T) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -11,6 +11,7 @@ import (
 const VERSION_STRING string = "Regent/0.0.0"
 const GENESIS_HASH_STRING = "0x03cbee8fac5256aa39823eb6437acf0918f2829e1775554cdd08f9519bf3e9e1"
 
+var GENESIS_HASH = common.HexToHash("0x03cbee8fac5256aa39823eb6437acf0918f2829e1775554cdd08f9519bf3e9e1")
 var DEV_ADDRESS = common.HexToAddress("0x013068165Fe8257f960C6831745927f924b2dd0d")
 
 func FromHex(input string) []byte {


### PR DESCRIPTION
New Features:
- Save current head on each chain update. Restore on startup.
- Create db package with strongly typed tables
- Create blocksIterator, a convenient way to iterate over the entire rollup history.
- Add a config object to Regent
- Unit test
- Integration test with Erigon